### PR TITLE
CI: use system gettext on x86_64-unknown-linux-musl

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -31,7 +31,8 @@ jobs:
           - rust-version: stable
             env:
               TARGET: x86_64-unknown-linux-musl
-              DOCKER: musl
+              DOCKER: musl-gettext
+              GETTEXT_SYSTEM: 1 # Workaround for https://github.com/Koka/gettext-rs/issues/99
             name: "x86_64 with musl, Rust stable"
           - rust-version: stable
             env:

--- a/ci/Dockerfile-musl-gettext
+++ b/ci/Dockerfile-musl-gettext
@@ -4,4 +4,5 @@ RUN apt-get update
 RUN apt-get install -y --no-install-recommends \
   gcc ca-certificates make libc6-dev gdb git patch wget xz-utils automake \
   autoconf \
-  musl-tools
+  musl-tools \
+  gettext

--- a/ci/local
+++ b/ci/local
@@ -18,9 +18,9 @@ case "$1" in
     export TARGET=i686-unknown-linux-gnu
     export DOCKER=linux32
     ;;
-  musl)
+  musl-gettext)
     export TARGET=x86_64-unknown-linux-musl
-    export DOCKER=musl
+    export DOCKER=musl-gettext
     ;;
   build)
     export TARGET=x86_64-unknown-linux-gnu


### PR DESCRIPTION
This works around a segfault in tests: https://github.com/Koka/gettext-rs/issues/99