### PR TITLE
Fix build failure on clang 16: turn off incompatible-function-pointer-types

### DIFF
--- a/gettext-sys/Cargo.toml
+++ b/gettext-sys/Cargo.toml
@@ -22,3 +22,4 @@ gettext-system = []
 [build-dependencies]
 cc = "1.0"
 temp-dir = "0.1.11"
+regex = "1"

--- a/gettext-sys/build.rs
+++ b/gettext-sys/build.rs
@@ -180,6 +180,9 @@ fn main() {
         // Avoid undefined reference to `__imp_xmlFree'
         cflags.push("-DLIBXML_STATIC");
     }
+    if target.contains("apple-darwin") {
+        cflags.push("-Wno-error=incompatible-function-pointer-types");
+    }
 
     let mut cmd = Command::new("tar");
     cmd.current_dir(&build_dir.join("gettext"))

--- a/gettext-sys/build.rs
+++ b/gettext-sys/build.rs
@@ -1,5 +1,6 @@
 extern crate cc;
 extern crate temp_dir;
+extern crate regex;
 
 use std::env;
 use std::ffi::OsString;
@@ -7,6 +8,7 @@ use std::fs;
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use regex::Regex;
 use temp_dir::TempDir;
 
 fn env(name: &str) -> Option<String> {

--- a/gettext-sys/build.rs
+++ b/gettext-sys/build.rs
@@ -82,8 +82,41 @@ fn check_dependencies(required_programs: Vec<&str>) {
     }
 }
 
+fn check_clang_version() -> Option<u8> {
+    // ${CC} --version | head -n 1 | grep -o -E "[[:digit:]]+.[[:digit:]].[[:digit:]]"
+    match env("CC") {
+        Some(cc) => { 
+            println!("cargo:warning=found cc {}", &cc);
+            if cc != "clang" {return None;}
+        }
+        None => {return None;}
+    };
+    let output = match  Command::new("clang")
+            .arg("--version")
+            .output() {
+        Ok(s) => String::from_utf8(s.stdout).unwrap_or_else( |_| String::new() ),
+        Err(_) => { return None; }
+    };
+
+            println!("cargo:warning=found cc {:?}", &output);
+
+    Some(2)
+    /*
+    let errors: String = required_programs.iter().map(|x| command(x)).collect();
+
+    if !errors.is_empty() {
+        fail(&format!("The following programs were not found:{}", errors));
+    }
+    */
+
+}
+
 fn main() {
     let target = env::var("TARGET").unwrap();
+
+    let clang_version = check_clang_version();
+    println!("cargo:warning=found cc {:?}", &clang_version);
+    return;
 
     if cfg!(feature = "gettext-system") || env("GETTEXT_SYSTEM").is_some() {
         if target.contains("linux") && (target.contains("-gnu") || target.contains("-musl")) {

--- a/gettext-sys/build.rs
+++ b/gettext-sys/build.rs
@@ -102,6 +102,12 @@ fn check_clang_version() -> Option<u8> {
 
             println!("cargo:warning=found cc {:?}", &output);
 
+    let re = Regex::new(r"clang version (?<major>\d+)\.(?<minor>\d+)\.*").unwrap();
+    let Some(caps) = re.captures(&output) else { return None };
+    let major = caps.name("major").unwrap().as_str().parse::<u8>().unwrap_or(0);
+
+            println!("cargo:warning=found cc {:?}", &caps);
+            println!("cargo:warning=found cc {:?}", &major);
     Some(2)
     /*
     let errors: String = required_programs.iter().map(|x| command(x)).collect();


### PR DESCRIPTION
This PR is a workaround for https://github.com/Koka/gettext-rs/issues/114