### PR TITLE
CI: update macOS

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -102,7 +102,7 @@ jobs:
         run: cargo generate-lockfile
 
       - name: Cache Cargo dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: ${{ hashFiles('**/Cargo.lock') }}
           path: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -46,7 +46,7 @@ jobs:
         run: cargo generate-lockfile
 
       - name: Cache Cargo dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: ${{ hashFiles('**/Cargo.lock') }}
           path: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build_and_test_macos:
     name: "ci/run.sh on macOS"
-    runs-on: macos-11
+    runs-on: macos-12
     env:
       # Disable progress bar in Cargo. This cuts down on output, avoiding log length limits.
       TERM: dumb

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -9,24 +9,33 @@ on:
 jobs:
   build_and_test_macos:
     name: "ci/run.sh on macOS"
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.sys.os }}
     env:
       # Disable progress bar in Cargo. This cuts down on output, avoiding log length limits.
       TERM: dumb
-      TARGET: x86_64-apple-darwin
+      TARGET: ${{ matrix.sys.target }}
 
     strategy:
       fail-fast: false
       matrix:
         use_homebrew: [false, true]
-        os: ["macos-12", "macos-13"]
+        sys:
+          - os: macos-12
+            target: x86_64-apple-darwin
+            gettext_dir: /usr/local/opt/gettext
+          - os: macos-13
+            target: x86_64-apple-darwin
+            gettext_dir: /usr/local/opt/gettext
+          - os: macos-14
+            target: aarch64-apple-darwin
+            gettext_dir: /opt/homebrew
 
     steps:
       - name: Install gettext from Homebrew
         if: ${{ matrix.use_homebrew }}
         run: |
           brew install gettext
-          echo 'GETTEXT_DIR=/usr/local/opt/gettext' >> $GITHUB_ENV
+          echo "GETTEXT_DIR=${{ matrix.sys.gettext_dir }}" >> $GITHUB_ENV
 
       - uses: hecrj/setup-rust-action@v2
         with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build_and_test_macos:
     name: "ci/run.sh on macOS"
-    runs-on: macos-12
+    runs-on: ${{ matrix.os }}
     env:
       # Disable progress bar in Cargo. This cuts down on output, avoiding log length limits.
       TERM: dumb
@@ -19,6 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         use_homebrew: [false, true]
+        os: ["macos-12", "macos-13"]
 
     steps:
       - name: Install gettext from Homebrew


### PR DESCRIPTION
MacOS 11 was removed from GitHub hosted runners a few weeks ago. This PR replaces it with the three versions that are available. That includes macOS 14 which runs on Apple Silicon.