### PR TITLE
Enable `gettext-system` feature on FreeBSD with GNU Gettext installed…

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -22,6 +22,9 @@ task:
 
     env:
         HOME: /home/testuser
+        matrix:
+          - {} # empty on purpose -- we don't want to set `GETTEXT_SYSTEM`
+          - GETTEXT_SYSTEM: 1
 
     after_cache_script:
       - mkdir $HOME/.cargo || true
@@ -30,6 +33,7 @@ task:
         - pkg update -f
         - pkg upgrade -y
         - pkg install -y rust gmake
+        - if [ "x$GETTEXT_SYSTEM" != "x" ]; then pkg install -y gettext gettext-runtime; fi
     setup_script:
         - pw groupadd testgroup
         - pw useradd testuser -g testgroup -w none -m

--- a/gettext-sys/README.md
+++ b/gettext-sys/README.md
@@ -25,6 +25,7 @@ abide by LGPL**. If you don't want or can't do that, there are two ways out:
         ```
         pacman --noconfirm -S base-devel mingw-w64-x86_64-gcc libxml2-devel tar
         ```
+    * FreeBSD with GNU gettext installed as a package or port;
 
     If none of those conditions hold, the crate will proceed to building and
     statically linking its own copy of GNU gettext!

--- a/gettext-sys/build.rs
+++ b/gettext-sys/build.rs
@@ -100,6 +100,10 @@ fn main() {
             println!("cargo:rustc-link-lib=dylib=pthread");
             println!("cargo:include={}/../usr/include", &gnu_root);
             return;
+        } else if target.contains("freebsd") {
+            println!("cargo:rustc-link-search=native=/usr/local/lib");
+            println!("cargo:rustc-link-lib=dylib=intl");
+            return;
         }
         // else can't use system gettext on this target
     }

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -7,6 +7,11 @@ use std::process::{self, Command};
 fn main() {
     let mut cfg = ctest2::TestGenerator::new();
 
+    let target = env::var("TARGET").unwrap();
+    if target.contains("freebsd") {
+        cfg.include("/usr/local/include");
+    }
+
     if let Ok(out) = env::var("DEP_GETTEXT_INCLUDE") {
         cfg.include(&out);
     }


### PR DESCRIPTION
Enables `gettext-system` feature on FreeBSD by linking with libintl installed via packages or ports. References bug https://github.com/gettext-rs/gettext-rs/issues/117 discussion.