### PR TITLE
Fix cross-compile: Skip binary execution when cross compiling

### DIFF
--- a/systest/Cargo.toml
+++ b/systest/Cargo.toml
@@ -10,3 +10,6 @@ gettext-sys = { path = "../gettext-sys" }
 
 [build-dependencies]
 ctest2 = "0.4"
+
+[features]
+cross_compiling = []

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -5,9 +5,18 @@ use std::path::{Path, PathBuf};
 use std::process::{self, Command};
 
 fn main() {
+    let target = env::var("TARGET").unwrap();
+    let host = env::var("HOST").unwrap();
+    let is_cross = target != host;
+
+    // Set the cross_compiling flag before the tests
+    if is_cross {
+        println!("cargo:rustc-cfg=cross_compiling");
+        println!("cargo::rustc-check-cfg=cfg(cross_compiling)");
+    }
+
     let mut cfg = ctest2::TestGenerator::new();
 
-    let target = env::var("TARGET").unwrap();
     if target.contains("freebsd") {
         cfg.include("/usr/local/include");
     }
@@ -22,24 +31,38 @@ fn main() {
     // Skip ptr check because the symbol name is different between glibc
     // implementation and static lib.
     // eg. gettext is libintl_gettext in static lib
-    if env::var_os("GETTEXT_SYSTEM").is_none() || env::var("TARGET").unwrap().contains("windows") {
+    if env::var_os("GETTEXT_SYSTEM").is_none() || target.contains("windows") {
         println!("Skipping ptr check");
         cfg.skip_fn_ptrcheck(|_| true);
     }
 
     cfg.generate("../gettext-sys/lib.rs", "all.rs");
 
-    // Check that we can find and run gettext binary
+    // Check for the existence of the gettext binary
     let cmd = if let Some(bin) = env::var_os("DEP_GETTEXT_BIN") {
         Path::new(&bin).join("gettext")
     } else {
         PathBuf::from("gettext")
     };
-    let c = Command::new(&cmd).arg("--version").spawn();
-    if let Ok(mut child) = c {
-        assert!(child.wait().unwrap().success());
-    } else {
-        println!("Could not run {}", cmd.display());
+
+    if !cmd.exists() {
+        println!(
+            "cargo:warning=Gettext binary not found at {}",
+            cmd.display()
+        );
         process::exit(1);
+    }
+
+    // Only run the binary if not cross-compiling
+    if !is_cross {
+        let c = Command::new(&cmd).arg("--version").spawn();
+        if let Ok(mut child) = c {
+            assert!(child.wait().unwrap().success());
+        } else {
+            println!("Could not run {}", cmd.display());
+            process::exit(1);
+        }
+    } else {
+        println!("cargo:warning=Cross-compiling detected. Gettext binary found but not executed.");
     }
 }

--- a/systest/src/main.rs
+++ b/systest/src/main.rs
@@ -1,17 +1,19 @@
+#![allow(bad_style)]
 #![allow(unused_imports)]
+extern crate gettext_sys;
 
-#[cfg(not(cross_compiling))]
+#[cfg(not(feature = "cross_compiling"))]
 use gettext_sys::*;
 
 #[cfg(not(cross_compiling))]
 include!(concat!(env!("OUT_DIR"), "/all.rs"));
 
-#[cfg(cross_compiling)]
+#[cfg(feature = "cross_compiling")]
 fn main() {
     println!("Cross-compilation detected. Skipping system tests.");
 }
 
-#[cfg(cross_compiling)]
+#[cfg(feature = "cross_compiling")]
 #[test]
 fn dummy_cross_compile_test() {
     println!("Cross-compilation detected. Skipping system tests.");

--- a/systest/src/main.rs
+++ b/systest/src/main.rs
@@ -1,7 +1,18 @@
-#![allow(bad_style)]
+#![allow(unused_imports)]
 
-extern crate gettext_sys;
-
+#[cfg(not(cross_compiling))]
 use gettext_sys::*;
 
+#[cfg(not(cross_compiling))]
 include!(concat!(env!("OUT_DIR"), "/all.rs"));
+
+#[cfg(cross_compiling)]
+fn main() {
+    println!("Cross-compilation detected. Skipping system tests.");
+}
+
+#[cfg(cross_compiling)]
+#[test]
+fn dummy_cross_compile_test() {
+    println!("Cross-compilation detected. Skipping system tests.");
+}


### PR DESCRIPTION
During cross compilation the systest crate shouldn't attempt to execute the binaries that were compiled. 
Simply checking for their existence should suffice.